### PR TITLE
Factor out `UniqueWidget`

### DIFF
--- a/lib/core/mapsindoors_widget.dart
+++ b/lib/core/mapsindoors_widget.dart
@@ -1,7 +1,7 @@
 part of '../mapsindoors.dart';
 
-/// A [UniqueWidget] that contains the map used by MapsIndoors
-class MapsIndoorsWidget extends UniqueWidget {
+/// A singleton widget that contains the map used by MapsIndoors
+class MapsIndoorsWidget extends StatefulWidget {
   final MPFloorSelector? floorSelector;
   final MPMapLabelFont? mapLabelFont;
   final int? textSize;


### PR DESCRIPTION
Hey!

It probably feels super random to see this pull request out-of-the-blue: the Flutter framework team is in the process of deprecating the `UniqueWidget` class, and there's a chance that it will be [removed without warning](https://github.com/flutter/flutter/issues/150459).

To my knowledge, this is the only public codebase on the internet that uses a `UniqueWidget`, so that's pretty unique!

`UniqueWidget` is 100% useless (since a global key works the exact same way inside a regular `StatefulWidget`), so this change won't have any effect on your plugin's runtime behavior.

Thanks for reading; have a nice day!